### PR TITLE
update: 블로그 포스트 '2025 KWDC 톺아보기' 내용 수정 및 스벨트와 리액트의 반응성 비교 추가

### DIFF
--- a/blog/2025-08-23-feconf.md
+++ b/blog/2025-08-23-feconf.md
@@ -31,325 +31,824 @@ FE conf 내용 정리
 
 ## 스벨트를 통해 리액트 더 잘 이해하기
 
-### 리랜더링 방식의 차이
+미세한 반응성(Fine-Grained Reactivity), DOM 조작 패턴, 그리고 트랜지션까지
 
-랜더링 방식에 있어서의 리액트와 스벨트의 차이 두 프레임워크의 상태관리를 통해 비교
+프론트엔드 코드가 커질수록 <em>“필요한 부분만”</em> 계산·업데이트하는 능력이 중요해집니다. 스벨트(Svelte)는 컴파일 타임에 미세한 반응성(Fine-Grained Reactivity, 이하 FGR)을 녹여 넣고, 리액트(React)는 런타임의 선언적 모델과 메모이제이션으로 최적화를 유도합니다. 이 글은 스벨트의 관점으로 리액트를 다시 바라보며, FGR의 원리를 직접 구현·응용해 보는 실전 가이드입니다.
 
-리액트에서 어떤 상태를 변경하더라도 컴포넌트 전체가 재실행된다.
+### 리렌더링 철학의 차이
 
-카운트 상태를 바꿔도 네임 상태를 바꿔도 useState에서는 모두 리랜더링
+#### 리액트: 상태 변경 → 컴포넌트 함수 재실행
 
-```jsx
-export default function example() {
-  const [count, setCount] = useState();
-  const [name, setName] = useState();
+리액트에서 useState의 값이 변하면 컴포넌트 함수 전체가 다시 호출됩니다. 필요한 부분만 실제 DOM 패치가 일어나도록 가상 DOM 비교와 메모이제이션이 도와주지만, 기본 규칙은 <em>“다시 호출”</em>이에요.
+
+```js
+import { useState } from "react";
+
+export default function Example() {
+  const [count, setCount] = useState(0);
+  const [name, setName] = useState("Lee");
 
   return (
     <div>
-      <div>{count}</div>
-      <div>{name}</div>
+      <div>count: {count}</div>
+      <div>name: {name}</div>
+
+      <button onClick={() => setCount((c) => c + 1)}>+1</button>
+      <button onClick={() => setName((n) => n + "!")}>rename</button>
     </div>
   );
 }
 ```
 
-스벨트의 구조 사용된곳만 업데이트하도록 되어있음
+여기서 count만 바꿔도 함수는 통째로 재실행됩니다.
 
-FGR이란 무엇인가
+#### 스벨트: 사용된 곳만 업데이트 (컴파일러 주도 FGR)
 
-Fine-Granined Reactivity 이펙트와 옵저버블로 구현
+스벨트는 컴파일 단계에서 “어떤 상태가 어디에서 쓰이는지”를 분석하여, 상태가 바뀔 때 그 상태를 참조한 DOM 조각만 갱신합니다. 스벨트 5의 룬(rune) 문법인 $state는 이 FGR을 아주 간단한 문법으로 노출합니다.
 
-상태가 변경될때 사용된 이펙트만 다시 실행
+```js
+<script>
+  let count = $state(0);
+  let name = $state("Lee");
+</script>
 
-이펙트 함수 구현방식에 대한 설명
+<div>count: {count}</div>
+<div>name: {name}</div>
 
-이펙트의 핵십요소 동적 추적 시스템 선택적 실행
+<button on:click={() => (count = count + 1)}>+1</button>
+<button on:click={() => (name = name + "!")}>rename</button>
+```
 
-옵저버블 클래스 구현 방식 설명
+상태 count만 바뀌면 해당 바인딩 영역만 갱신됩니다. “컴파일러가 의존성을 추출해 놓았다”라고 이해하면 편합니다.
 
-동적의존성 추적 겟 호출 시점에 이펙트를 자동으로 수집하여 의존성 그래프를 동적으로 구성
+### FGR란 무엇인가: 이펙트와 옵저버블의 뼈대
 
-콜백 컬렉션
-값을 사용하는 모든 이펙트를 콜백
+<strong>FGR(Fine-Grained Reactivity)</strong>는 값 단위로 의존성을 추적하고, 값이 바뀌면 그 값을 사용한 이펙트만 재실행하는 모델입니다.
 
-스벨트의 $state 와 FGR 스벨트에서는 이런 반응성을 컴파일러를 통해 더욱 쉽게 사용
+핵심은 두 가지예요.
 
-$state로 간편한 FGR 구현 방식 코드
+1. 옵저버블 값: get()과 set()을 가진 값 컨테이너
+2. 이펙트: 실행 중 읽힌(get) 옵저버블을 자동 구독 → 그 값이 바뀌면 재실행
 
-스벨트 컴파일러 동작 방식에 대한 설명
+아래는 FGR의 최소 구현(컨셉 데모)입니다.
 
-스벨트 컴파일 결과 코드
+```js
+// ── 최소 FGR 런타임 ─────────────────────────────────────────────
+const ACTIVE_EFFECT_STACK = [];
 
-리액트에서의 FGR Legend State
+export function observable(initial) {
+  let value = initial;
+  const subscribers = new Set();
 
-스벨트의 세밀한 반응성을 리액트에서도 적용할 수 있을까?
+  function get() {
+    const active = ACTIVE_EFFECT_STACK[ACTIVE_EFFECT_STACK.length - 1];
+    if (active) subscribers.add(active);
+    return value;
+  }
 
-EXPO에서 공식 지원하는 FGR 라이브러리
+  function set(next) {
+    if (Object.is(value, next)) return;
+    value = next;
+    subscribers.forEach((fn) => fn());
+  }
 
-사용 예시 코드
+  return { get, set };
+}
 
-메모 컴포넌트 패턴, FGR 원리 적용
+export function effect(fn) {
+  const runner = () => {
+    try {
+      ACTIVE_EFFECT_STACK.push(runner);
+      fn(); // 실행 중에 읽힌(get) observable들이 이 이펙트를 자동 구독
+    } finally {
+      ACTIVE_EFFECT_STACK.pop();
+    }
+  };
+  runner();
+  return () => {
+    // 간단 버전: 구독 해제 생략(실전은 필요시 구현)
+  };
+}
+```
 
-### Dom 조작 패턴
+사용 예:
 
-이벤트 처리와 DOM조작방식의 차이
+```js
+const count = observable(0);
+const name = observable("Lee");
 
-외부 클릭하면 닫히는 동작 예시
+effect(() => {
+  console.log("count changed ->", count.get());
+});
 
-일반적인 구현방법
+effect(() => {
+  console.log("name changed ->", name.get());
+});
 
-DOM요소 참조하기 useRef로 드롭다운이나 모달 요소 참조 추적
+count.set(1); // count 이펙트만 실행
+name.set("Kim"); // name 이펙트만 실행
+```
 
-외부 클릭 판단 방법들
+이것이 스벨트/솔리드(Solid) 계열 반응성의 핵심 아이디어입니다. _“그 값을 실제로 읽은 코드만 다시 돈다.”_
 
-- contains() 메서드로 클릭된 요소가 참조한 돔ㅇ내부인지 확인
+### 스벨트의 `$state`와 FGR
 
-- 이벤트 리스너 관리
+스벨트 5의 `$state`는 위 원리를 컴파일 타임에 자동 적용합니다. 의존성 추적은 런타임 코드가 아니라 <strong>컴파일러가 생성</strong>한 코드로 이뤄지므로, 런타임 오버헤드가 낮은 게 강점이죠. 결과적으로 <em>“문법은 간결, 동작은 세밀”</em>이 됩니다.
 
-- useEffect로 사용
+스벨트 컴파일 결과를 뜯어보면(요약) `count`를 읽는 자리에 업데이트 슬롯이 삽입·연결되고, `count = count + 1` 같은 대입 시 해당 슬롯만 갱신합니다. 즉, 위 미니 런타임에서 했던 의존성 그래프 생성·통지를 컴파일된 코드가 직접 수행합니다.
 
-재사용 가능하게 한다면?
+### 리액트에서 FGR은 불가능할까? (Legend-State 등으로 응용)
 
-- 훅 방식
+리액트 세계에서도 <strong>신호형 값(Observable/Signal)</strong>과 선택적 구독을 도입하면 FGR에 가까운 모델을 만들 수 있습니다. 예를 들어, 아래는 <strong>아주 작은 신호(signal)</strong>를 만들고, 컴포넌트가 그 신호만 구독하도록 하는 패턴입니다.
 
-코드 예시
+```js
+// signal.ts
+type Listener = () => void;
 
-Handler와 DOM에 적용되는 로직이 분리되어있음 돔에 어떤 로직이 적용되어있는지 알기 어려움
+export function signal<T>(initial: T) {
+  let value = initial;
+  const subs = new Set<Listener>();
 
-컴포넌트 방식
+  return {
+    get() {
+      return value;
+    },
+    set(next: T) {
+      if (Object.is(value, next)) return;
+      value = next;
+      subs.forEach((l) => l());
+    },
+    subscribe(l: Listener) {
+      subs.add(l);
+      return () => subs.delete(l);
+    },
+  };
+}
+```
 
-시맨틱 태그가 드러나지 않아 가독성이 떨어지고 이게 헤더인지 섹션인지 넵바인지 구분 모호
+```js
+// useSignal.ts
+import { useSyncExternalStore, useMemo } from "react";
 
-스벨트에서는 어떻게 할까
+export function useSignal<T>(sig: {
+  get: () => T,
+  subscribe: (l: () => void) => () => void,
+}) {
+  const getSnapshot = () => sig.get();
+  const subscribe = (l: () => void) => sig.subscribe(l);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+```
 
-use: direcitve로 dom 직접 조작
+```js
+// App.tsx
+import { signal } from "./signal";
+import { useSignal } from "./useSignal";
 
-use: 지시어로 DOM에 직접 기능을 추가
+const count = signal(0);
+const name = signal("Lee");
 
-돔과 로직이 같은 위치 이해하기 쉽고 직관적
+function Count() {
+  const c = useSignal(count); // count만 구독
+  return (
+    <div>
+      count: {c} <button onClick={() => count.set(c + 1)}>+1</button>
+    </div>
+  );
+}
 
-리엑트 ref 콜백 패턴에 적용한다면??
+function Name() {
+  const n = useSignal(name); // name만 구독
+  return (
+    <div>
+      name: {n} <button onClick={() => name.set(n + "!")}>rename</button>
+    </div>
+  );
+}
 
-리액트에서 ref 는 useRef의 리턴값을 할당할 수 있는걸 넘어서 element의 생성과 소멸시점에 대한 콜백을 받을수있음 이를 홀용한 코드 예시
+export default function App() {
+  return (
+    <>
+      <Count />
+      <Name />
+    </>
+  );
+}
+```
 
-ref에 dom조작 콜백함수 응용
+위 구조는 <strong>Count</strong>가 다시 그려져도 <strong>Name</strong>은 건드리지 않습니다. 반대로도 마찬가지. 즉, _“상태 단위로 의존성을 구독하는”_ FGR의 이점을 리액트에서도 누릴 수 있습니다.
 
-ref에 돔 조작 콜백함수를 넘기면서 응용한다면
+> 참고: React 생태계에는 이러한 아이디어를 품은 서드파티 라이브러리(예: Legend-State 등)가 존재하며, React/React Native/Expo 프로젝트에서도 신호형 상태를 적용하는 선택지가 있습니다. 팀의 규모·취향에 따라 도입을 검토해 보세요.
 
-react19의 ref 콜백 패턴
+### DOM 조작 패턴: 예시 _“밖을 클릭하면 닫기”_
 
-새로운 useOutside
+#### (A) 전통적 훅 패턴
 
-### 애니메이션 구현
+일반적으로는 `useRef` + `useEffect` + 전역 클릭 리스너로 구현합니다.
 
-돔 요소 생성/ 소멸시 자연스러운 움직임을 부여하는 기법
+```js
+import { useEffect, useRef, useState } from "react";
 
-리액트 트랜지션 구현의 현실
+function useOnClickOutside(ref, handler) {
+  useEffect(() => {
+    function onClick(e) {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target)) handler(e);
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [ref, handler]);
+}
 
-리액트에서 요소의 등장/ 퇴장 애니메이션을 외부 라이브러리에 의존해야함
+export default function Dropdown() {
+  const ref = useRef(null);
+  const [open, setOpen] = useState(false);
+  useOnClickOutside(ref, () => setOpen(false));
 
-기본 동작의 한계 리액트에서는 즉시 제거하기 때문
+  return (
+    <div ref={ref}>
+      <button onClick={() => setOpen((v) => !v)}>toggle</button>
+      {open && <div className="menu">menu</div>}
+    </div>
+  );
+}
+```
 
-모션의 경우 모든 기능이 동작하지만 api 래핑이 복잡하고 어려움
+단점: <em>“DOM에 어떤 로직이 붙는지”</em>가 <strong>컴포넌트 외곽</strong>으로 흩어져 있어 가독성이 떨어질 수 있어요.
 
-스벨트의 내장 트랜지현과 api 스벨트는 트랜지션이 내장되어있어 애니메이션ㄴ을 쉽게 구현할 수 있다..
+#### (B) 스벨트: use: 디렉티브(액션)로 DOM에 직접 기능 부여
 
-기본 트랜지션 별도 라이브러리 없이 사옹 가능
+스벨트는 DOM 요소에 직접 “액션”을 붙입니다. 로직과 DOM이 한곳에 있어 직관적이에요.
 
-커스텀 트랜지션 정의
+```html
+<script>
+  export function clickOutside(node, handler) {
+    function onClick(e) {
+      if (!node.contains(e.target)) handler(e);
+    }
+    document.addEventListener('mousedown', onClick);
+    return {
+      destroy() {
+        document.removeEventListener('mousedown', onClick);
+      }
+    };
+  }
 
-tick 값을 받아 설정할 수 있음
+  let open = $state(false);
+</script>
 
-인 커스텀 아웃 커스텀을 사용하여 진입과 퇴장 따로 설정 가능
+<div use:clickOutside={() => (open = false)}>
+  <button on:click={() => (open = !open)}>toggle</button>
+  {#if open}<div class="menu">menu</div>{/if}
+</div>
+```
 
-리액트에 적용 가능할까??
+#### (C) 리액트에 액션 패턴 이식: ref 콜백을 이용하자
 
-리액트 dom의 생성/소멸 시점을 감지할 수 있으니 이를 활요하여 구현할 수 있음
+리액트의 `ref`는 <strong>객체(ref.current)</strong>만 받는 게 아니라 <strong>함수(콜백)</strong>도 받을 수 있습니다. 이 콜백은 <strong>DOM 생성/소멸 시점</strong>에 호출되므로 스벨트의 `use:` 액션과 유사한 패턴을 만들 수 있습니다.
 
-이런 hook도 가능하지 않을까/?
+```js
+// makeAction.tsx — 리액트용 "액션" 헬퍼
+type Action<T extends Element> = (el: T) => void | (() => void);
 
-돔 생성 소멸 시점에 자연스러운 애니메이션 부여
+export function makeAction<T extends Element>(action: Action<T>) {
+  let cleanup: (() => void) | undefined;
 
-ref에 transition 훅을 사용하여 인아웃 적용
+  return (el: T | null) => {
+    // el이 마운트될 때
+    if (el && !cleanup) {
+      const ret = action(el);
+      cleanup = typeof ret === "function" ? ret : undefined;
+    }
+    // el이 언마운트될 때
+    if (!el && cleanup) {
+      cleanup();
+      cleanup = undefined;
+    }
+  };
+}
+```
 
-스고이 라이브러리?
+```js
+// useOutside.tsx — 밖을 클릭하면 닫기
+import { makeAction } from "./makeAction";
 
-https://ssgoi.dev
+export function outside(action: (e: MouseEvent) => void) {
+  return makeAction<HTMLElement>((node) => {
+    const onClick = (e: MouseEvent) => {
+      if (!node.contains(e.target as Node)) action(e);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  });
+}
+```
+
+```js
+// Dropdown.tsx — 사용 예
+import { useState } from "react";
+import { outside } from "./useOutside";
+
+export default function Dropdown() {
+  const [open, setOpen] = useState(false);
+  const attachOutside = outside(() => setOpen(false));
+
+  return (
+    <div ref={attachOutside}>
+      <button onClick={() => setOpen((v) => !v)}>toggle</button>
+      {open && <div className="menu">menu</div>}
+    </div>
+  );
+}
+```
+
+이렇게 하면 <strong>DOM과 로직이 같은 위치</strong>에 있고, 생성/소멸 수명주기도 자연스럽게 처리됩니다. (React 19에서도 콜백 ref 패턴은 그대로 유효합니다.)
+
+### 애니메이션/트랜지션: 등장·퇴장을 자연스럽게
+
+#### 리액트의 현실과 한계
+
+리액트는 요소를 조건부 렌더링에서 `false`/`null`이면 즉시 제거합니다. 그래서 _“퇴장 애니메이션 후 제거”_ 같은 동작에는 <strong>상태 지연</strong>이나 <strong>외부 라이브러리</strong>(Framer Motion 등)가 필요합니다.
+
+#### 스벨트: 내장 트랜지션이 기본 제공
+
+스벨트는 `transition:` 지시어로 쉽게 씁니다.
+
+```html
+<script>
+  import { fade, fly } from 'svelte/transition';
+  let open = $state(false);
+</script>
+
+<button on:click={() => (open = !open)}>toggle</button>
+
+{#if open}
+  <div transition:fade>간단 페이드</div>
+  <div transition:fly={{ y: 10, duration: 150 }}>슬쩍 이동</div>
+{/if}
+```
+
+커스텀 트랜지션도 함수로 만들 수 있어요. 함수는 `(node, params)`를 받아 `css` 또는 `tick`(매 프레임 호출)을 반환합니다.
+
+```html
+<script>
+  function grow(node, { duration = 200 } = {}) {
+    const h = node.offsetHeight;
+    return {
+      duration,
+      css: (t) => `height: ${t * h}px; overflow: hidden;`
+    };
+  }
+  let open = $state(false);
+</script>
+
+<button on:click={() => (open = !open)}>toggle</button>
+{#if open}
+  <div transition:grow>늘어나는 박스</div>
+{/if}
+```
+
+#### 리액트에서 “퇴장 후 제거” 구현: Presence 훅(Web Animations API 버전)
+
+외부 의존성을 줄인 소형 훅입니다. <strong>나갈 때 애니메이션</strong> → <strong>끝나면 unmount</strong> 흐름을 처리해요.
+
+```js
+// usePresence.ts
+import { useEffect, useRef, useState } from "react";
+
+type KeyframesOrFactory =
+  | Keyframe[]
+  | PropertyIndexedKeyframes
+  | ((el: Element, mode: "in" | "out") => Keyframe[]);
+
+export function usePresence(
+  show: boolean,
+  keyframes: KeyframesOrFactory,
+  options?: KeyframeAnimationOptions
+) {
+  const [present, setPresent] = useState(show); // 실제로 렌더할지
+  const modeRef = (useRef < "in") | ("out" > "in");
+  const elRef = (useRef < HTMLElement) | (null > null);
+
+  useEffect(() => {
+    if (show) setPresent(true);
+    modeRef.current = show ? "in" : "out";
+  }, [show]);
+
+  useEffect(() => {
+    const el = elRef.current;
+    if (!el) return;
+    const frames =
+      typeof keyframes === "function"
+        ? keyframes(el, modeRef.current)
+        : keyframes;
+    const anim = el.animate(frames, {
+      duration: 180,
+      easing: "ease-out",
+      fill: "both",
+      ...options,
+    });
+    if (modeRef.current === "out") {
+      anim.onfinish = () => setPresent(false);
+    }
+    return () => anim.cancel();
+  }, [present, show, keyframes, options]);
+
+  const ref = (node: HTMLElement | null) => {
+    elRef.current = node;
+  };
+
+  return { present, ref };
+}
+```
+
+```js
+// FadeSlide.tsx — 사용 예
+import { useState } from "react";
+import { usePresence } from "./usePresence";
+
+export default function Demo() {
+  const [open, setOpen] = useState(false);
+  const { present, ref } = usePresence(
+    open,
+    (el, mode) =>
+      mode === "in"
+        ? [
+            { opacity: 0, transform: "translateY(6px)" },
+            { opacity: 1, transform: "translateY(0)" },
+          ]
+        : [
+            { opacity: 1, transform: "translateY(0)" },
+            { opacity: 0, transform: "translateY(6px)" },
+          ],
+    { duration: 200 }
+  );
+
+  return (
+    <div>
+      <button onClick={() => setOpen((v) => !v)}>toggle</button>
+      {present && (
+        <div ref={ref} style={{ willChange: "opacity, transform" }}>
+          부드러운 등장/퇴장
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+리액트에서도 <strong>DOM 생성/소멸 시점을 잡아</strong> 적절한 애니메이션을 적용하면 스벨트 내장 트랜지션과 거의 같은 UX를 낼 수 있습니다. (규모가 커지면 Framer Motion, React Transition Group 등도 실전에서 훌륭한 선택지예요. 다만 위처럼 “핵심 로직을 직접 이해한 뒤” 라이브러리를 쓰는 것이 유지보수에 유리합니다.)
+
+#### 메모 컴포넌트 패턴에 FGR 접목
+
+리액트에서 `memo`, `useMemo`, `useCallback`은 <strong>불필요한 재실행을 줄이는 기본 도구</strong>입니다. 여기에 <strong>신호형 상태</strong>(위 signal 예시)를 결합하면, <em>“컴포넌트는 작게 쪼개고, 각 컴포넌트는 필요한 신호만 구독”</em>하는 구조를 손쉽게 만들 수 있습니다.
+
+```js
+import { memo } from "react";
+import { signal } from "./signal";
+import { useSignal } from "./useSignal";
+
+const price = signal(100);
+const qty = signal(1);
+
+const Total = memo(function Total() {
+  const p = useSignal(price);
+  const q = useSignal(qty);
+  return <div>Total: {p * q}</div>;
+});
+
+const Qty = memo(function Qty() {
+  const q = useSignal(qty);
+  return <button onClick={() => qty.set(q + 1)}>+1</button>;
+});
+
+export default function Cart() {
+  return (
+    <>
+      <Total />
+      <Qty />
+    </>
+  );
+}
+```
+
+이 패턴은 <strong>의존성 단위로만 다시 그림</strong>을 보장합니다. 렌더 트리 규모가 커질수록 차이가 눈에 띱니다.
+
+### 마무리: 스벨트로 보는 리액트, 리액트로 배우는 스벨트
+
+- 스벨트는 컴파일러가 FGR을 자동 생성하므로, 문법이 간결하고 기본이 빠릅니다.
+
+- 리액트는 런타임 선언 모델을 취하지만, 신호형 상태 + 선택적 구독 + 콜백 ref 같은 패턴을 도입하면 FGR의 이점을 상당 부분 흉내 낼 수 있습니다.
+
+- DOM 액션 패턴, 등장/퇴장 트랜지션도 <strong>“생성/소멸 시점”과 “의존성 단위”</strong>를 잘 잡아주면 두 프레임워크 모두에서 일관된 설계를 만들 수 있습니다.
+
+:::note 참고
+
+스벨트의 FGR 감각을 유지한 채 리액트/리액트 네이티브/Expo 프로젝트에서도 신호형 상태를 쓰고 싶다면, Legend-State처럼 신호·스토어·파생값을 제공하는 경량 라이브러리를 검토해 보세요. 팀 합의와 DX(디버깅, DevTools)도 함께 고려하는 것이 좋습니다.
+
+:::
+
+### 부록: 새 useOutside(콜백 ref 기반) – 최종 형태
+
+```ts
+// useOutside.tsx
+import { useCallback } from "react";
+
+type Options = {
+  event?: "mousedown" | "click" | "pointerdown";
+  enabled?: boolean;
+};
+
+export function useOutside(onOutside: (e: Event) => void, opts: Options = {}) {
+  const { event = "mousedown", enabled = true } = opts;
+
+  const ref = useCallback(
+    (node: HTMLElement | null) => {
+      if (!enabled || !node) return;
+
+      const onEvt = (e: Event) => {
+        if (!node.contains(e.target as Node)) onOutside(e);
+      };
+
+      document.addEventListener(event, onEvt);
+      return () => {
+        document.removeEventListener(event, onEvt);
+      };
+    },
+    [onOutside, event, enabled]
+  );
+
+  return ref; // <div ref={ref}> 에 바로 꽂아서 사용
+}
+```
+
+```ts
+// 사용
+function Menu() {
+  const [open, setOpen] = useState(false);
+  const ref = useOutside(() => setOpen(false), { event: "pointerdown" });
+
+  return (
+    <div ref={ref}>
+      <button onClick={() => setOpen((v) => !v)}>toggle</button>
+      {open && <div className="menu">menu</div>}
+    </div>
+  );
+}
+```
 
 ## 'memo'를 지울결심: React Compiler가 제안하는 미래
 
-### React Compiler러란?
+> “언제 `memo`, `useMemo`, `useCallback`을 써야 하죠?”<br/>
+> React Compiler의 대답은 간단합니다. <strong>“대부분의 경우, 신경 쓰지 마세요.”</strong>
 
-react forget으로 개발 시작
+### React Compiler란?
 
-ract conf 2024 정식 오픈
+- 초기 **React Forget**으로 연구가 시작되어, **React Conf 2024** 무대에서 정식으로 공개된 컴파일러 기반 최적화입니다.
+- 목표는 **수동 메모이제이션** 걱정을 줄이고, React의 룰을 잘 지키면 **컴파일러가 자동으로 연산을 캐싱/스킵**하게 만드는 것입니다.
 
-#### React compiler를 알아보기 전에 리액트 특성을 확인
+### 리액트의 기본 특성 다시 보기
+
+#### 부모가 리렌더되면, 자식도 리렌더된다
 
-리액트의 특성 부모 컴포넌트가 리랜더링 된다면 자식 컴포넌트도 리랜더링
+리액트는 상태 변경 시 **컴포넌트 함수가 재호출**됩니다. 부모가 다시 실행되면 자식도 다시 실행되는 것이 기본 규칙이죠.
 
-기존의 메모이제이션 방식 useMemo, useCallback을 사용해서 관리
+#### 그래서 지금까지는 수동 메모이제이션을 했다
 
-그렇다면 모든곳에 적용하면 좋지 않을까?
+`memo`, `useMemo`, `useCallback`으로 **불필요한 재실행**과 **재생성**을 막아왔습니다. 하지만 “어디에, 어느 정도로 쓰느냐”가 항상 고민거리였죠
 
-#### 수동 메모이제이션의 한계
+#### 모든 곳에 다 쓰면 좋을까? → No
 
-과도한 리소스 소모 의존성 배열 관리 코드의 본질이 가려짐
+- 오버헤드(의존성 배열 관리, 코드 부피 증가)
+- 가독성 저하(본질 로직이 최적화 코드에 파묻힘)
+- 버그 위험(의존성 누락/과잉)
 
-최적화 코드가 너무 많아져 코드의 본래의도가 희석됨
+### 수동 메모이제이션의 한계 → React Compiler 등장
 
-어떤 기준을 가지고 메모이제이션 해야할까? 개발자가 메모이제이션을 신경쓰지 않아도 좋다면 어떨까?
+React Compiler는 **코드를 분석하여 자동으로 메모이제이션 지점을 삽입**합니다. 즉, 개발자는 <strong>React의 규칙(Rules of React)</strong>을 지키며 로직을 쓰면 되고, **최적화는 컴파일러가 책임**지는 방향으로 진화합니다.
 
--> React Compiler 등장
+### 컴파일러는 실제로 무엇을 하나?
 
-Readct Compiler 동작 방식
+> 아래 코드는 이해를 위한 의사 코드입니다(실제 내부 구현과 다를 수 있음).
 
-어떤 식으로 거쳐갈까
+#### (1) 캐시 슬롯을 만드는 내부 훅: useMemoCache(size)
 
-useMemoCache 훅이 생성된 사이즈를 입력 받아 fiber 노드 상에 저장된 배열형태의 캐시 저장
+컴파일러는 컴포넌트마다 “필요한 캐시 슬롯 개수”를 계산해 두고, **Fiber 노드에 배열 형태로 저장**합니다.
 
-조건문을 통해 추가함
+```js
+// 원본 (개념)
+function Text({ color }) {
+  const style = { color }; // 매 렌더마다 객체 생성
+  return <span style={style}>Hello</span>;
+}
+```
 
-이때 심볼을 통해 캐시값들을 저장하며, 이에 대한 컴파일 결과 코드를 통해 발표자가 설명함
+```js
+// 컴파일 후 의사 코드
+function Text_compiled({ color }) {
+  const $ = useMemoCache(1); // 캐시 슬롯 1개 확보
+  let style;
 
-캐시의 첫번째 값과 심볼 비교 심볼을 이때 캐시의 초기값을 가져옴
+  // 첫 렌더: 캐시 미존재 → 계산 후 저장
+  if ($[0] === undefined || $[0].**key !== color) {
+    style = { color };
+    $[0] = { **key: color, **val: style }; // 심볼/키로 동일성 추적
+  } else {
+    style = $[0].\*\*val; // 캐시 재사용
+  }
 
-if 문은 첫 랜더링 시 캐싱을 하는 과정
+  return <span style={style}>Hello</span>;
+}
+```
 
-첫 랜더링 시 첫번째 값을 $[0]에 저장하고 이후 활용함
+핵심 아이디어:
 
-else는 리랜더링 될때 확인 하는 부분
+- <strong>리액티브 값(시간에 따라 변할 수 있는 값)</strong>을 기준으로 동일성 체크 키를 만들고, **변하지 않았다면 재계산/재생성을 건너뜀**.
 
-사이즈 2의 캐시배열을 받는 텍스트 컴포넌트 예시
+#### (2) 조건 분기에서도 분기별 캐시를 둔다
 
-컬러가 다를 때 jsx반환 같다면 캐시 값을 그대로 씀
+```js
+// 원본
+function Badge({ variant }) {
+  if (variant === "success") {
+    const s = { background: "green", color: "white" };
+    return <span style={s}>OK</span>;
+  } else {
+    const s = { background: "gray", color: "black" };
+    return <span style={s}>NG</span>;
+  }
+}
+```
 
-부모에 상태가 추가된다면?
+```js
+// 컴파일 후 의사 코드
+function Badge_compiled({ variant }) {
+  const $ = useMemoCache(2); // 각 분기에 1칸씩
+  if (variant === "success") {
+    if ($[0] === undefined) $[0] = { background: "green", color: "white" };
+    return <span style={$[0]}>OK</span>;
+  } else {
+    if ($[1] === undefined) $[1] = { background: "gray", color: "black" };
+    return <span style={$[1]}>NG</span>;
+  }
+}
+```
 
-App() 에 useState(0); 추가된다면
+분기 전환이 일어나지 않는 한,** 각 분기에서 한 번 만든 객체를 계속 재사용**합니다.
 
-카운트가 증가하면 자식 요소가 다시 계산됨
+#### (3) 부모 상태 추가 → 자식 재계산? 컴파일러가 막아준다
 
-자식에게 비싼 연산이 있다면 매번 재계산 되므로 메모이제이션을 활용했었음
+```js
+function App() {
+  const [count, setCount] = useState(0);
+  return (
+    <>
+      <button onClick={() => setCount((c) => c + 1)}>{count}</button>
+      <Text color="tomato" /> {/_ 여기 안의 style 계산을 스킵 _/}
+    </>
+  );
+}
+```
 
-컴파일러는 어떻게 동작할까??
+부모가 리렌더되어도 `Text`의 리액티브 키(여기선 `color`)가 변하지 않으면, 컴파일러는 **자식 내부의 비싼 연산/생성**을 자동으로 스킵하도록 변환합니다.
 
-텍스트의 경우 컬러가 다시 달라지지 않는 이상 다시 계산되지 않는다.
+### “컴파일러”의 분석 파이프라인 한눈에
 
-컴파일 과정 깊이 들어가기
+> “컴파일이냐 트랜스파일이냐?” 용어는 중요하지 않습니다. 핵심은 고수준 React 코드를 분석하여 저수준 형태(HIR 등)로 바꿔 최적화 정보를 주입한 뒤 다시 JS로 방출한다는 점.
 
-컴파일? 트랜스파일??
+1. 파싱(AST)
+   Babel 등으로 소스 코드를 <strong>AST(Abstract Syntax Tree)</strong>로 변환.
 
-컴파일이란 고수준의 언어에서 저수준으로 변환하는 과정이므로 트랜스파일러가 맞지않을까?
+2. HIR(High-level IR) 작성
+   AST가 구문 구조라면, HIR은 <strong>실행 흐름 단위(블록/엣지)</strong>를 표현.
 
-진입점
+- 블록: 실행 단위
+- 엣지: 블록 간 제어 흐름
 
-babel 을 통해 자바스크립트 코드를 파싱하여 추상 구문 트리로 변환 abstract syntax tree
+3. SSA(Static Single Assignment)
 
-HIR
+   - 변수에 단 한 번만 할당되도록 재작성(버저닝).
+   - 재할당을 버전으로 관리하면 데이터 흐름 분석이 쉬워짐.
 
-AST는 코드의 구조를 나타낸다면 HIR은 코드의 실행 흐름을 나타낸다 실행단위인 블럭과 블럭사이의 엣지로 표현한다
+4. Reactive 분석
 
-블럭이라는 단위와 엣지라는 실행흐름
+- “시간에 따라 변할 수 있는 값(리액티브 값)”을 식별:
+  - props/함수 파라미터(부모가 언제든 바꿀 수 있음)
+  - 훅 호출 결과(useState, useContext, useSelector 등)
+  - 전역/외부 상태 접근 값
+  - 위에서 파생된 값(계산 결과)
 
-SSA
+5. Reactive 스코프 형성
 
-정적 단일 대입 각 변수가 단 한번만 할당되도록 제한하는 형식
+- 리액티브 값의 <strong>영향 범위(스코프)</strong>를 그룹화.
+- 각 스코프 경계에 캐시 슬롯과 키 비교 로직을 배치.
 
-재할당 되는 변수들을 버저닝 해준다
+6. JS로 방출
 
-Reactive 분석
+- 내부 HIR/스코프 정보를 반영하여 컴파일된 React 코드를 출력.
+- 결과적으로 개발자가 직접 쓰지 않아도 <strong>“조건부/분기별 캐싱”</strong>이 자동 삽입됨.
 
-어떤 값들이 시간에따라 변할 수 있는 지 리액티브를 분석
+### 개발자 입장에서 느껴질 변화
 
-함수 파라미터 프롭스 아규먼트 부모 컴포넌트에서 전달되어 언제든 변함
+✅ 좋은 소식
 
-훅 호출 결과
+- “여기 useMemo 필요할까?” 고민이 크게 줄어듦
+- 분기별 캐시처럼 사람이 손으로 하기 번거로운 최적화를 자동으로
 
-전역 상태에 접근하는 값
+⚠️ 그래도 지켜야 할 것(낙관적 가정의 비용)
 
-이값에서 파생되는 값들
+컴파일러는 <string>React의 규칙(Rules of React)</string>이 지켜진다는 **낙관적 가정** 하에 동작합니다.
+규칙 위반(순수성 깨짐, 랜더 중 부수효과, 훅 순서 변경 등)은 <string>에러가 아닌 “오동작”</string>으로 나타날 수 있어요.
 
-리액티브 값이란 리랜더링을 유발할 수 있는 잠재적인 값
+- 대처 방법
+  - ESLint + React 플러그인을 켜고, 경고를 없앨 것
+  - 부수효과는 useEffect로 옮기고, 렌더는 순수하게
+  - 안정성 보강 도구: react-forgive(experimental) — LSP 기반으로 컴파일 추론을 노출/보조
 
-리액티브 분석
+📦 번들 크기 주의
 
-어떤 값들이 시간에 따라 변할 수 있는지 분석
+- 컴포넌트 단위로 변환 코드가 추가됩니다.
+- 리액티브 값/분기가 많을수록 코드량이 증가할 수 있습니다.
+- 간단 예제에서 2.28배 늘어난 사례가 보고되지만(예시), 실제 수치는 코드베이스/코드스플리팅 여부에 따라 다릅니다.
+  → 코드스플리팅과 불필요한 리액티브 값 최소화가 여전히 중요.
 
-리액티브 스코프
+### 새 멘탈 모델: React as a Language
 
-영향을 받는 코드 영역을 그룹화
+React를 “라이브러리”라기보다 언어처럼 생각하면 컴파일러와 궁합이 좋아집니다.
 
-각 스코프를 기준으로 나뉘어 메모이제이션
+1. 룰을 엄격히 준수
 
-다시 자바스크립트로 변환
+- 렌더는 순수 함수처럼: 동등 입력 → 동등 출력
+- 훅은 탑레벨에서 동일 순서로 호출
+- 부수효과는 Effect 계층으로
 
-HIR 형태에서 트리구조인 reactiveFunction으로 변환
+2. “변하는 값”을 선명히 파악
 
-다시 JavaScript 코드로 변환
+- 무엇이 리액티브인지(언제/어디서 바뀌는지) 의식적으로 구분
+- 변하지 않는 값은 상수/모듈 상단 등으로 탈리액티브화.
 
-컴파일이란 메모이제이션 과정에서 보듯 ~(못들음)
+3. 조건 분기 = 스코프 분리
 
-컴파일러의 한계와 우려
+- `if (variant === 'a')`처럼 분기가 명확하면, 각 분기에서 별도 캐시가 자리 잡아 이득을 봄.
 
-낙관적 가정, 번들 사이즈
+### 실전 예제로 보는 “값의 변화 흐름”과 캐시
 
-낙관적 가정
+#### (A) “직전값과 비교”가 핵심
 
-컴파일된 코드가 예상과 다르게 동작할 때 발생하게된다
+```js
+function ColorText({ color }) {
+  const style = { color }; // 컴파일러가 color를 키로 캐시
+  return <span style={style}>Hi</span>;
+}
+```
 
-리액트 컴파일러는 기본적으로 Rules of React를 지켰다는 가정하에 이뤄지게됨
+- `color`가 같으면 **style 재생성**은 스킵.
 
-순수성을 위반한 코드들은 의도 하지 않은 동작이 발생
-에러로 관측되지 않음
+#### (B) 순회/정렬 같은 비싼 연산도 자동 스킵
 
-이를 방지할 방법은?
+```js
+function List({ items, sort }) {
+  // sort가 바뀌지 않으면 정렬 결과 캐시를 재사용
+  const sorted = [...items].sort(sort);
+  return (
+    <ul>
+      {sorted.map((i) => (
+        <li key={i.id}>{i.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
 
-리액트의 규칙을 작 지키자
+#### (C) 분기별로 “캐시 하나씩”
 
-eslint 등 툴 활용
+```js
+function PriceTag({ currency, amount }) {
+  if (currency === "KRW") {
+    const text = new Intl.NumberFormat("ko-KR").format(amount);
+    return <span>{text}원</span>;
+  } else {
+    const text = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(amount);
+    return <span>{text}</span>;
+  }
+}
+```
 
-react forgive(experimental) 실험적기능
+- KRW 분기에서 만든 `text`는 KRW 분기에 캐시,
+- USD/JPY 등 다른 분기는 **각각의 캐시**를 가짐.
 
-리액트 컴파일러를 Language Server 프로토콜로 사용하는 익스텐션
+#### (D) 리액티브 값의 중첩과 캐시 전략
 
-컴파일 결과를 미리 확인하거나 추론을 더 명확하게 해줌
+1. 하나의 캐시에 몰아넣는 경우:
 
-번들 크기
+- “들어올 값 종류를 예측하기 어렵다”면 범용 캐시 1개로, **키(파생값 조합)**로 구분.
 
-리액트 컴파일러는 컴포넌트 단위의 코드 변환이 이뤄짐. 리액티브 값이 많을수록 변환된 코드양 증가
+2. 분기별로 쪼개는 경우:
 
-단순한 예제에서 컴포넌트 사이즈 2.28배 증가
-
-복잡하고 코드 스플릿팅이 잘 되지 않았다면 크기가 증가하게됨
-
-리액트 컴파일러 시대의 멘탈 모델
-
-react as a language
-
-리액트를 언어와도 같은 레벨로 취급하여 스트릭하게 룰을 잘 지킴
-
-변화하는 값에 대한 이해
-
-딸기 당근 수박 을 값으로 받는 컴포넌트
-
-props를 통해 받았을때
-
-직전값과 비교하므로 순회하는 경우 차이가 없음
-
-if 문을 활용 시
-같은 값이 들어오면 다시 계산하지 않음
-
-리액티브 값의 중첩
-
-첫번째는 밸류에 어떤값이 올지 모르므로 하나의 캐시에 모든 상태 중첩
-
-두번째의 경우 각 분기마다 하나씩만 저장하므로 각 분기마다 캐시 하나씩 적용
-
-앞으로 무엇에 집중해야할까???
-
-수동 메모이제이션에서 해방
-변화하는 값들이 어떻게 흐르는가 이해하고 접근하자
+- `if/else`, `switch` 등 스코프가 명확하면 분기마다 캐시 슬롯을 갖게 되어 더 미세하게 스킵.
 
 ## 중요하지만 중요하지 않은 일, 그럼에도 계속해야하는 웹 접근성
 

--- a/blog/2025-08-23-feconf.md
+++ b/blog/2025-08-23-feconf.md
@@ -427,8 +427,8 @@ export function usePresence(
   options?: KeyframeAnimationOptions
 ) {
   const [present, setPresent] = useState(show); // 실제로 렌더할지
-  const modeRef = (useRef < "in") | ("out" > "in");
-  const elRef = (useRef < HTMLElement) | (null > null);
++  const modeRef = useRef<"in" | "out">("in");
++  const elRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (show) setPresent(true);
@@ -561,24 +561,26 @@ type Options = {
 
 export function useOutside(onOutside: (e: Event) => void, opts: Options = {}) {
   const { event = "mousedown", enabled = true } = opts;
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const handlerRef = useRef(onOutside);
+  useEffect(() => {
+    handlerRef.current = onOutside;
+  }, [onOutside]);
 
-  const ref = useCallback(
-    (node: HTMLElement | null) => {
-      if (!enabled || !node) return;
+  useEffect(() => {
+    if (!enabled) return;
+    const onEvt = (e: Event) => {
+      const node = nodeRef.current;
+      if (!node) return;
+      if (!node.contains(e.target as Node)) handlerRef.current(e);
+    };
+    document.addEventListener(event, onEvt);
+    return () => document.removeEventListener(event, onEvt);
+  }, [enabled, event]);
 
-      const onEvt = (e: Event) => {
-        if (!node.contains(e.target as Node)) onOutside(e);
-      };
-
-      document.addEventListener(event, onEvt);
-      return () => {
-        document.removeEventListener(event, onEvt);
-      };
-    },
-    [onOutside, event, enabled]
-  );
-
-  return ref; // <div ref={ref}> 에 바로 꽂아서 사용
+  return useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node;
+  }, []);
 }
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서화
  - “스벨트를 통해 리액트 더 잘 이해하기” 섹션을 FGR(미세 반응성) 관점 중심으로 전면 재구성했습니다.
  - observable/effect 기반 미니 런타임 구현 예시와 $state, signal, useSignal 등 신호형 상태 패턴을 다수 추가했습니다.
  - DOM 액션/디렉티브 패턴과 React ref/콜백 비교, useOutside·makeAction 같은 실전 헬퍼 예시를 보강했습니다.
  - 트랜지션·애니메이션 통합 사례와 React에서의 유사 UX 구현 방향을 제시했습니다.
  - 컴파일러 기반 최적화 아이디어(파이프라인·캐시 슬롯 등), DX/도구 권장사항, 코드 스플리팅·캐시·파생값 부록을 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->