### PR TITLE
update: 이력서 링크를 Notion에서 Canva로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Enable Corepack

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Enable Corepack

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,7 +73,7 @@ const config = {
           {to: '/blog', label: '기록', position: 'left'},
           {to: 'showcase', label: 'Showcase', position: 'left'},
           {
-            href: 'https://evanescent-table-194.notion.site/Frontend-0866085aac3c4c619efbd9ab1d940329',
+            href: 'https://www.canva.com/design/DAGz-nqnzUs/hqoQlPIJGeUcR_Zt0MYSRA/view?utm_content=DAGz-nqnzUs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h675136036a',
             label: 'Resume',
             position: 'right',
           },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 문서화
  * 상단 내비게이션의 “Resume” 링크를 Notion에서 Canva 디자인 보기로 업데이트했습니다. 라벨·위치·동작은 동일합니다.
* 정비(Chores)
  * CI/CD 워크플로우에서 사용되는 Node.js 버전을 v18에서 v20으로 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->