### PR TITLE
update: 포트폴리오 링크를 메뉴에 추가

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,6 +78,11 @@ const config = {
             position: 'right',
           },
           {
+            href: 'https://www.canva.com/design/DAG0FtTtc7Q/5bxilRwjMyASzdWmJYeuIA/watch?utm_content=DAG0FtTtc7Q&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he3cc71b0d4',
+            label: 'Portfolio',
+            position: 'right',
+          },
+          {
             href: 'https://open.kakao.com/o/sEenYDXg',
             label: 'CoffeeChat',
             position: 'right',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 사이트 상단 내비게이션 바에 ‘Portfolio’ 항목을 추가했습니다. 클릭 시 Canva 포트폴리오 페이지로 이동합니다. 기존 ‘Resume’ 등 다른 메뉴에는 변화가 없으며, 링크는 오른쪽에 배치되었습니다. 사용자들은 포트폴리오를 한 번의 클릭으로 빠르게 확인할 수 있습니다. 모바일과 데스크톱 모두에서 동일하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->